### PR TITLE
chore: add branch policy enforcement and fix gitflow release workflow

### DIFF
--- a/.github/workflows/branch-policy.yml
+++ b/.github/workflows/branch-policy.yml
@@ -24,8 +24,8 @@ jobs:
           fi
 
           if [ "$TARGET" = "develop" ]; then
-            if [[ "$SOURCE" != feature/* && "$SOURCE" != bugfix/* && "$SOURCE" != "master" ]]; then
-              echo "PRs to develop must come from feature/*, bugfix/*, or master branches (got: $SOURCE)"
+            if [[ "$SOURCE" != feature/* && "$SOURCE" != bugfix/* && "$SOURCE" != chore/* && "$SOURCE" != "master" ]]; then
+              echo "PRs to develop must come from feature/*, bugfix/*, chore/*, or master branches (got: $SOURCE)"
               exit 1
             fi
           fi

--- a/.github/workflows/gitflow-release.yml
+++ b/.github/workflows/gitflow-release.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -38,10 +39,24 @@ jobs:
           git tag "v${{ steps.version.outputs.version }}"
           git push origin "v${{ steps.version.outputs.version }}"
 
-      - name: Back-merge master into develop
+      - name: Create back-merge branch
         run: |
-          git fetch origin develop
-          git checkout develop
-          git merge --no-ff origin/master \
-            -m "chore: back-merge master into develop after ${{ github.event.pull_request.head.ref }}"
-          git push origin develop
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "chore/back-merge-${{ steps.version.outputs.version }}"
+          git push origin "chore/back-merge-${{ steps.version.outputs.version }}"
+
+      - name: Open back-merge PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr create \
+            --base develop \
+            --head "chore/back-merge-${{ steps.version.outputs.version }}" \
+            --title "chore: back-merge master into develop after v${{ steps.version.outputs.version }}" \
+            --body "Automated back-merge of \`master\` into \`develop\` following the \`${{ github.event.pull_request.head.ref }}\` release." \
+            --label "chore" || true
+          gh pr merge "chore/back-merge-${{ steps.version.outputs.version }}" \
+            --auto \
+            --merge \
+            --delete-branch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 env:
   IMAGE_NAME: ghcr.io/${{ github.repository }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 
-## [0.2.0] - 2026-03-07
+## [v0.2.1] - 2026-03-07
+
+### Added
+
+- **Branch policy** — New `branch-policy.yml` workflow enforces gitflow naming conventions on pull requests; PRs targeting `master` must originate from `release/*` or `hotfix/*`, and PRs targeting `develop` must originate from `feature/*`, `bugfix/*`, `chore/*`, or `master`
+
+### Changed
+
+- **Release tagging** — Tags now use a `v` prefix (e.g. `v0.2.1`) to comply with Go module versioning requirements
+- **Back-merge** — Post-release back-merge from `master` into `develop` now opens a pull request via `gh pr create --auto` instead of pushing directly, respecting branch protection rules
+
+## [v0.2.0] - 2026-03-07
 
 ### Changed
 


### PR DESCRIPTION
  ## Description                                                                                                                                                       
                                                                                                                                                                       
  Enforces gitflow branch naming conventions via a new GitHub Actions status check, fixes release tags to use the `v` prefix required by Go modules, and replaces the  
  direct back-merge push with an auto-merge PR to comply with branch protection rules on `develop`.

  Closes #

  ---

  ## Type of change

  - [ ] Bug fix (`bugfix/<name>`)
  - [ ] New feature (`feature/<name>`)
  - [ ] Hotfix (`hotfix/<name>`)
  - [ ] Release prep (`release/<version>`)
  - [x] Documentation / chore

  ## Changes

  - Added `.github/workflows/branch-policy.yml` — fails CI if a PR targets `master` from anything other than `release/*` or `hotfix/*`, or targets `develop` from
  anything other than `feature/*`, `bugfix/*`, `chore/*`, or `master`
  - Updated `.github/workflows/gitflow-release.yml` — tags now push with a `v` prefix (e.g. `v0.2.1`); back-merge creates a `chore/back-merge-<version>` branch and
  opens a PR with `--auto` merge instead of pushing directly to `develop`
  - Updated `CHANGELOG.md` — added entries for `v0.2.0` and `v0.2.1`

  ## Testing

  - [x] `go test ./...` passes locally
  - [x] Tested against a real `config.toml` (run `go run . -config config.toml`)
  - [ ] Tested in Docker (`docker build` + `docker run`)

  ## Config schema changes

  - [ ] This PR modifies `config.toml` fields or behaviour — docs / example config updated accordingly

  ## Screenshots

  N/A — no UI changes

  ---

  ## Checklist

  - [x] Branch follows gitflow naming (`feature/`, `bugfix/`, `hotfix/`, `release/`)
  - [x] Commits are signed (`git config commit.gpgsign true`)
  - [x] `go fmt ./...` run and no lint warnings introduced
  - [x] `CHANGELOG.md` updated (for features and bug fixes)
  - [x] PR title is descriptive and suitable for a changelog entry