### PR TITLE
hotfix: make release tag creation idempotent to survive workflow re-runs

### DIFF
--- a/.github/workflows/gitflow-release.yml
+++ b/.github/workflows/gitflow-release.yml
@@ -36,8 +36,12 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag "v${{ steps.version.outputs.version }}"
-          git push origin "v${{ steps.version.outputs.version }}"
+          if git rev-parse "v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
+            echo "Tag v${{ steps.version.outputs.version }} already exists, skipping."
+          else
+            git tag "v${{ steps.version.outputs.version }}"
+            git push origin "v${{ steps.version.outputs.version }}"
+          fi
 
       - name: Create back-merge branch
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 
+## [v0.2.2] - 2026-03-07
+
+### Fixed
+
+- **GitFlow release workflow** — Tag creation is now idempotent; re-running the workflow no longer fails if the tag already exists
+
 ## [v0.2.1] - 2026-03-07
 
 ### Added


### PR DESCRIPTION
  ## Description                                                                                                                                                       
                                                                                                                                                                       
  Fixes the GitFlow release workflow to skip tag creation if the tag already exists,                                                                                   
  preventing failures when the workflow is re-run after a partial execution.

  Closes #

  ---

  ## Type of change

  - [ ] Bug fix (`bugfix/<name>`)
  - [ ] New feature (`feature/<name>`)
  - [x] Hotfix (`hotfix/<name>`)
  - [ ] Release prep (`release/<version>`)
  - [ ] Documentation / chore

  ## Changes

  - Updated `.github/workflows/gitflow-release.yml` — tag creation now checks for an existing tag before running `git tag` and `git push`, skipping silently if the tag
   is already present
  - Updated `CHANGELOG.md` — added entry for `v0.2.2`

  ## Testing

  - [ ] `go test ./...` passes locally
  - [ ] Tested against a real `config.toml` (run `go run . -config config.toml`)
  - [ ] Tested in Docker (`docker build` + `docker run`)

  ## Config schema changes

  - [ ] This PR modifies `config.toml` fields or behaviour — docs / example config updated accordingly

  ## Screenshots

  N/A — no UI changes

  ---

  ## Checklist

  - [ ] Branch follows gitflow naming (`feature/`, `bugfix/`, `hotfix/`, `release/`)
  - [ ] Commits are signed (`git config commit.gpgsign true`)
  - [ ] `go fmt ./...` run and no lint warnings introduced
  - [x] `CHANGELOG.md` updated (for features and bug fixes)
  - [x] PR title is descriptive and suitable for a changelog entry