### PR TITLE
hotfix: make release tag creation idempotent to survive workflow re-runs

### DIFF
--- a/.github/workflows/branch-policy.yml
+++ b/.github/workflows/branch-policy.yml
@@ -24,8 +24,8 @@ jobs:
           fi
 
           if [ "$TARGET" = "develop" ]; then
-            if [[ "$SOURCE" != feature/* && "$SOURCE" != bugfix/* && "$SOURCE" != "master" ]]; then
-              echo "PRs to develop must come from feature/*, bugfix/*, or master branches (got: $SOURCE)"
+            if [[ "$SOURCE" != feature/* && "$SOURCE" != bugfix/* && "$SOURCE" != chore/* && "$SOURCE" != "master" ]]; then
+              echo "PRs to develop must come from feature/*, bugfix/*, chore/*, or master branches (got: $SOURCE)"
               exit 1
             fi
           fi

--- a/.github/workflows/gitflow-release.yml
+++ b/.github/workflows/gitflow-release.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -38,10 +39,24 @@ jobs:
           git tag "v${{ steps.version.outputs.version }}"
           git push origin "v${{ steps.version.outputs.version }}"
 
-      - name: Back-merge master into develop
+      - name: Create back-merge branch
         run: |
-          git fetch origin develop
-          git checkout develop
-          git merge --no-ff origin/master \
-            -m "chore: back-merge master into develop after ${{ github.event.pull_request.head.ref }}"
-          git push origin develop
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "chore/back-merge-${{ steps.version.outputs.version }}"
+          git push origin "chore/back-merge-${{ steps.version.outputs.version }}"
+
+      - name: Open back-merge PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr create \
+            --base develop \
+            --head "chore/back-merge-${{ steps.version.outputs.version }}" \
+            --title "chore: back-merge master into develop after v${{ steps.version.outputs.version }}" \
+            --body "Automated back-merge of \`master\` into \`develop\` following the \`${{ github.event.pull_request.head.ref }}\` release." \
+            --label "chore" || true
+          gh pr merge "chore/back-merge-${{ steps.version.outputs.version }}" \
+            --auto \
+            --merge \
+            --delete-branch

--- a/.github/workflows/gitflow-release.yml
+++ b/.github/workflows/gitflow-release.yml
@@ -36,8 +36,12 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag "v${{ steps.version.outputs.version }}"
-          git push origin "v${{ steps.version.outputs.version }}"
+          if git rev-parse "v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
+            echo "Tag v${{ steps.version.outputs.version }} already exists, skipping."
+          else
+            git tag "v${{ steps.version.outputs.version }}"
+            git push origin "v${{ steps.version.outputs.version }}"
+          fi
 
       - name: Create back-merge branch
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 
-## [0.2.0] - 2026-03-07
+## [v0.2.1] - 2026-03-07
+
+### Added
+
+- **Branch policy** — New `branch-policy.yml` workflow enforces gitflow naming conventions on pull requests; PRs targeting `master` must originate from `release/*` or `hotfix/*`, and PRs targeting `develop` must originate from `feature/*`, `bugfix/*`, `chore/*`, or `master`
+
+### Changed
+
+- **Release tagging** — Tags now use a `v` prefix (e.g. `v0.2.1`) to comply with Go module versioning requirements
+- **Back-merge** — Post-release back-merge from `master` into `develop` now opens a pull request via `gh pr create --auto` instead of pushing directly, respecting branch protection rules
+
+## [v0.2.0] - 2026-03-07
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 
+## [v0.2.2] - 2026-03-07
+
+### Fixed
+
+- **GitFlow release workflow** — Tag creation is now idempotent; re-running the workflow no longer fails if the tag already exists
+
 ## [v0.2.1] - 2026-03-07
 
 ### Added


### PR DESCRIPTION
  ## Description                                                                                                                                                       
                                                                                                                                                                       
  Fixes the GitFlow release workflow to skip tag creation if the tag already exists,                                                                                   
  preventing failures when the workflow is re-run after a partial execution.

  Closes #

  ---

  ## Type of change

  - [ ] Bug fix (`bugfix/<name>`)
  - [ ] New feature (`feature/<name>`)
  - [x] Hotfix (`hotfix/<name>`)
  - [ ] Release prep (`release/<version>`)
  - [ ] Documentation / chore

  ## Changes

  - Updated `.github/workflows/gitflow-release.yml` — tag creation now checks for an existing tag before running `git tag` and `git push`, skipping silently if the tag
   is already present
  - Updated `CHANGELOG.md` — added entry for `v0.2.2`

  ## Testing

  - [ ] `go test ./...` passes locally
  - [ ] Tested against a real `config.toml` (run `go run . -config config.toml`)
  - [ ] Tested in Docker (`docker build` + `docker run`)

  ## Config schema changes

  - [ ] This PR modifies `config.toml` fields or behaviour — docs / example config updated accordingly

  ## Screenshots

  N/A — no UI changes

  ---

  ## Checklist

  - [ ] Branch follows gitflow naming (`feature/`, `bugfix/`, `hotfix/`, `release/`)
  - [ ] Commits are signed (`git config commit.gpgsign true`)
  - [ ] `go fmt ./...` run and no lint warnings introduced
  - [x] `CHANGELOG.md` updated (for features and bug fixes)
  - [x] PR title is descriptive and suitable for a changelog entry