### PR TITLE
fix: correct Go module path and add manual release dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 
+## [v0.3.0] - 2026-03-07
+
+### Added
+
+- **Manual release dispatch** — `release.yml` now supports `workflow_dispatch` with a required `tag` input and an optional `dry_run` flag that builds and tests without publishing to GitHub Releases or GHCR
+
+### Fixed
+
+- **Go module path** — Corrected module declaration from `homestead` to `github.com/haydenk/homestead` in `go.mod` and all internal import paths, resolving Go proxy resolution errors
+
 ## [v0.2.2] - 2026-03-07
 
 ### Fixed

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module homestead
+module github.com/haydenk/homestead
 
 go 1.22.0
 

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"homestead/internal/config"
+	"github.com/haydenk/homestead/internal/config"
 )
 
 // Status holds the result of a single health check.

--- a/internal/checker/checker_test.go
+++ b/internal/checker/checker_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"homestead/internal/config"
+	"github.com/haydenk/homestead/internal/config"
 )
 
 // makeConfig builds a minimal Config containing the given items in a single section.

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/gorilla/websocket"
 
-	"homestead/internal/checker"
-	"homestead/internal/config"
+	"github.com/haydenk/homestead/internal/checker"
+	"github.com/haydenk/homestead/internal/config"
 )
 
 type pageData struct {

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -12,8 +12,8 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
-	"homestead/internal/checker"
-	"homestead/internal/config"
+	"github.com/haydenk/homestead/internal/checker"
+	"github.com/haydenk/homestead/internal/config"
 )
 
 // newTestServer builds a minimal Server suitable for handler testing,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
-	"homestead/internal/checker"
-	"homestead/internal/config"
+	"github.com/haydenk/homestead/internal/checker"
+	"github.com/haydenk/homestead/internal/config"
 )
 
 // Server holds all runtime state for the HTTP server.

--- a/main.go
+++ b/main.go
@@ -9,9 +9,9 @@ import (
 	"os/signal"
 	"syscall"
 
-	"homestead/internal/checker"
-	"homestead/internal/config"
-	"homestead/internal/server"
+	"github.com/haydenk/homestead/internal/checker"
+	"github.com/haydenk/homestead/internal/config"
+	"github.com/haydenk/homestead/internal/server"
 )
 
 //go:embed web


### PR DESCRIPTION
  ## Description                                                                                                                                                       
                                                                                                                                                                       
  Fixes the Go module path to comply with Go proxy requirements and adds a                                                                                             
  `workflow_dispatch` trigger to the release workflow so releases can be
  manually re-triggered without recreating tags.

  Closes #

  ---

  ## Type of change

  - [ ] Bug fix (`bugfix/<name>`)
  - [ ] New feature (`feature/<name>`)
  - [ ] Hotfix (`hotfix/<name>`)
  - [x] Release prep (`release/<version>`)
  - [ ] Documentation / chore

  ## Changes

  - Updated `go.mod` — module path corrected from `homestead` to `github.com/haydenk/homestead`
  - Updated `main.go`, `internal/checker/checker.go`, `internal/checker/checker_test.go`, `internal/server/handlers.go`, `internal/server/handlers_test.go`,
  `internal/server/server.go` — all internal imports updated to match new module path
  - Updated `.github/workflows/release.yml` — added `workflow_dispatch` trigger with `tag` (required) and `dry_run` (boolean) inputs; all `github.ref_name` references
  replaced with `RELEASE_TAG` env var so dispatch and tag-push triggers behave identically
  - Updated `CHANGELOG.md` — added entry for `v0.3.0`

  ## Testing

  - [x] `go test ./...` passes locally
  - [x] Tested against a real `config.toml` (run `go run . -config config.toml`)
  - [ ] Tested in Docker (`docker build` + `docker run`)

  ## Config schema changes

  - [ ] This PR modifies `config.toml` fields or behaviour — docs / example config updated accordingly

  ## Screenshots

  N/A — no UI changes

  ---

  ## Checklist

  - [x] Branch follows gitflow naming (`feature/`, `bugfix/`, `hotfix/`, `release/`)
  - [x] Commits are signed (`git config commit.gpgsign true`)
  - [x] `go fmt ./...` run and no lint warnings introduced
  - [x] `CHANGELOG.md` updated (for features and bug fixes)
  - [x] PR title is descriptive and suitable for a changelog entry