### PR TITLE
fix(checker): make Stop() idempotent via sync.Once

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -27,6 +27,7 @@ type Checker struct {
 	mu       sync.RWMutex
 	results  map[string]*Status
 	stopCh   chan struct{}
+	stopOnce sync.Once
 	notifyCh chan struct{}
 	client   *http.Client
 }
@@ -74,9 +75,9 @@ func (c *Checker) Start() {
 	}()
 }
 
-// Stop halts background checks.
+// Stop halts background checks. Safe to call multiple times.
 func (c *Checker) Stop() {
-	close(c.stopCh)
+	c.stopOnce.Do(func() { close(c.stopCh) })
 }
 
 // Notify returns a channel that receives a signal after each completed check round.

--- a/internal/checker/checker_test.go
+++ b/internal/checker/checker_test.go
@@ -419,6 +419,20 @@ func TestStartStop_DoesNotPanic(t *testing.T) {
 	c.Stop() // must not hang or panic
 }
 
+// Regression for issue #39: Stop() must be idempotent so deferred
+// cleanup layered on top of explicit shutdown logic does not
+// panic with "close of closed channel".
+func TestStop_IdempotentNoPanicOnDoubleCall(t *testing.T) {
+	c := New(&config.Config{CheckInterval: 1})
+	c.Stop()
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("second Stop() panicked: %v", r)
+		}
+	}()
+	c.Stop()
+}
+
 // --- CheckNow ---
 
 func TestCheckNow_IsNonBlocking(t *testing.T) {


### PR DESCRIPTION
Fixes haydenk/homestead#39.

## Problem

`Checker.Stop()` did `close(c.stopCh)` with no guard. A second call — trivially reached once graceful-shutdown plumbing (#38) layers explicit shutdown on top of deferred cleanup — panics:

```
panic: close of closed channel
```

## Fix

Wrap the close in a `sync.Once` so `Stop()` is a safe no-op on repeat, regardless of call order.

## Test

Added `TestStop_IdempotentNoPanicOnDoubleCall` which reproduces the panic against the previous code and passes with the fix.

```
ok  	github.com/haydenk/homestead/internal/checker	0.760s
```

(Rebranched from `fix/…` to `bugfix/…` per gitflow naming. Previous PR #74 closed.)