### PR TITLE
fix(server): guard Server.cfg with RWMutex

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -79,7 +79,7 @@ func newTemplate(webFS fs.FS) *template.Template {
 // GET /
 func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
 	data := pageData{
-		Config:   s.cfg,
+		Config:   s.getCfg(),
 		Statuses: s.checker.GetAll(),
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -145,7 +145,7 @@ func (s *Server) handleReload(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"`+err.Error()+`"}`, http.StatusInternalServerError)
 		return
 	}
-	s.cfg = newCfg
+	s.setCfg(newCfg)
 	s.checker.UpdateConfig(newCfg)
 	s.checker.CheckNow()
 	log.Printf("Config reloaded from %s", s.configPath)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -17,6 +18,10 @@ import (
 
 // Server holds all runtime state for the HTTP server.
 type Server struct {
+	// cfgMu guards cfg so that concurrent request handlers (handleIndex
+	// reads s.cfg, handleReload swaps it) don't race. Before this, go
+	// test -race flagged a data race between GET / and POST /api/reload.
+	cfgMu      sync.RWMutex
 	cfg        *config.Config
 	configPath string
 	checker    *checker.Checker
@@ -27,6 +32,20 @@ type Server struct {
 	mux        *http.ServeMux
 	hub        *hub
 	upgrader   websocket.Upgrader
+}
+
+// getCfg returns the current config under the server's read lock.
+func (s *Server) getCfg() *config.Config {
+	s.cfgMu.RLock()
+	defer s.cfgMu.RUnlock()
+	return s.cfg
+}
+
+// setCfg swaps the active config under the server's write lock.
+func (s *Server) setCfg(cfg *config.Config) {
+	s.cfgMu.Lock()
+	defer s.cfgMu.Unlock()
+	s.cfg = cfg
 }
 
 // New creates a configured Server.


### PR DESCRIPTION
Fixes haydenk/homestead#30.

## Problem

`handleIndex` read `s.cfg` while `handleReload` wrote it on a separate goroutine without synchronization. Concurrent `GET /` + `POST /api/reload` reliably flagged under `go test -race` and is a true data race per the Go memory model.

## Fix

Add `cfgMu sync.RWMutex` on `Server` along with `getCfg` / `setCfg` accessors, and switch the two call sites (`handlers.go:82`, `handlers.go:148`) to use them.

## Test

`go test -race ./internal/server/...` clean, including the existing reload tests.