### PR TITLE
fix(ci): use pull_request_target in Labeler workflow for fork PRs

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,7 +1,7 @@
 name: Labeler
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
   issues:
     types: [opened, edited]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Labeler workflow on fork PRs** — Switched the `Labeler` workflow's PR trigger from `pull_request` to `pull_request_target` so `GITHUB_TOKEN` retains write permissions on PRs from forks; the action only reads changed file paths and does not check out fork code (#77)
+
 
 ## [v0.3.0] - 2026-03-07
 


### PR DESCRIPTION
## Description

  The `Labeler` workflow fails on PRs from forks with `Resource not accessible by integration` because GitHub forces `GITHUB_TOKEN` to be read-only on `pull_request` events from forks, regardless of the workflow's `permissions:` block.

  Switching the trigger to `pull_request_target` runs the workflow in the base repo's context, restoring write access so the action can apply labels.

  This is safe for the labeler use case: the action only reads changed file paths via the API and does not check out or execute fork code.

  Closes #77

  ---

  ## Type of change

  - [x] Hotfix &nbsp;&nbsp;(`hotfix/<name>`)

  ## Changes

  - `.github/workflows/labeler.yml`: `pull_request` → `pull_request_target` for the `label-pr` job trigger
  - `CHANGELOG.md`: entry under `[Unreleased] / Fixed`

  ## Testing

  CI-only change; cannot be verified locally. Will verify after merge by reopening (or pushing to) PR #75 and confirming the labeler run succeeds and applies labels.

  ## Config schema changes

  - [x] N/A — workflow-only change

  ---

  ## Checklist

  - [x] Branch follows gitflow naming (`hotfix/labeler-fork-pr-permissions`)
  - [x] `CHANGELOG.md` updated
  - [x] PR title is descriptive and suitable for a changelog entry